### PR TITLE
Only open the quickfix window if there are valid errors

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -425,7 +425,7 @@ endfunction
 
 function! s:open_quickfix(request, copen) abort
   let was_qf = &buftype ==# 'quickfix'
-  execute 'botright' (!empty(getqflist()) || a:copen) ? 'copen' : 'cwindow'
+  execute 'botright' (!empty(filter(getqflist(), 'v:val.valid != 0')) || a:copen) ? 'copen' : 'cwindow'
   if &buftype ==# 'quickfix' && !was_qf && !a:copen
     wincmd p
   endif


### PR DESCRIPTION
Without this, the quickfix window might get openend even if there are no
actual errors, e.g because of the output generated by Makefiles
created by CMake.
