### PR TITLE
Call redraw

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -444,6 +444,7 @@ function! s:open_quickfix(request, copen) abort
       endif
     endif
   endfor
+  redraw
 endfunction
 
 " }}}1


### PR DESCRIPTION
On widnows, when background job finished completely, result window doesn't show. Added redraw.
