### PR TITLE
Scroll quicklist window to end on completion

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -428,6 +428,7 @@ function! s:open_quickfix(request, copen) abort
   let was_qf = &buftype ==# 'quickfix'
   execute 'botright' (!empty(getqflist()) || a:copen) ? 'copen' : 'cwindow'
   if &buftype ==# 'quickfix' && !was_qf && !a:copen
+    normal G4kzz
     wincmd p
   endif
   for winnr in range(1, winnr('$'))


### PR DESCRIPTION
This may not be useful to those using quickfix in a smarter way than me, but I find it useful to see the the end of the dispatch output, so I thought I'd share.

Thanks for the sweet plugin, BTW.
