### PR TITLE
Error displaying result pane when :pwd contains spaces

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -430,7 +430,7 @@ function! s:cgetfile(request, all, copen) abort
   let dir = getcwd()
   try
     call s:set_current_compiler(get(request, 'compiler', ''))
-    exe cd request.directory
+    exe cd fnameescape(request.directory)
     if a:all
       let &l:efm = '%+G%.%#'
     else
@@ -442,7 +442,7 @@ function! s:cgetfile(request, all, copen) abort
   catch '^E40:'
     return v:exception
   finally
-    exe cd dir
+    exe cd fnameescape(dir)
     let &l:efm = efm
     let &l:makeprg = makeprg
     call s:set_current_compiler(compiler)


### PR DESCRIPTION
If vim's current directory contains spaces, `:Dispatch` runs the command, but then fails to open the result pane, displaying the following error:

```
Error detected while processing function dispatch#compile_command..dispatch#complete..<SNR>102_cgetfile:
line   21:
E172: Only one file name allowed: cd /home/sstokes/hello world
Error detected while processing function dispatch#compile_command..dispatch#complete:
line   12:
E171: Missing :endif
Error detected while processing function dispatch#compile_command:
line   63:
E171: Missing :endif
```

Steps to reproduce:

``` bash
mkdir hello\ world
cd hello\ world
cat > Makefile <<MAKE
hello:
    echo Hello world
MAKE
vim Makefile
```

Then running `:Dispatch` or `:Make` will produce this error.
