### PR TITLE
Remove gnu vs osx specific sed buffer option

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -49,7 +49,7 @@ function! dispatch#tmux#make(request) abort
   let filter = 'sed'
   let uname = system('uname')[0:-2]
   if uname ==# 'Darwin'
-    let filter .= ' -l'
+    let filter = '/usr/bin/sed -l'
   elseif uname ==# 'Linux'
     let filter .= ' -u'
   endif


### PR DESCRIPTION
Hi Tim

I use gnu sed by default on osx, and google tells me I'm not the only one. I had to make the change in this patch to get vim-dispatch to work. Without this it fails silently (the error file is created empty).

I tried seeing if there was a reliable way to distinguish which sed flavour is installed, but failed to find a simple way. 

I'm not sure whether the sed buffering setting is really necessary so maybe the simplest is to get rid of it? Seems to work fine.

Cheers
Kris
