### PR TITLE
Mention a tmux version constraint in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,10 @@ Using dispatch.vim from a plugin is a simple matter of checking for and using
 favorite plugin already supports it, assuming your favorite plugin is
 [rails.vim](https://github.com/tpope/vim-rails).
 
+## Compatibility
+
+You'll be needing a `tmux -V` version of at least `1.6` for this plugin to work.
+
 ## Self-Promotion
 
 Like dispatch.vim?  Follow the repository on


### PR DESCRIPTION
I just upgraded from version `1.5` to `1.8` in order to get this extension to work. I think other users would save some debug time if they were informed of this. A colleague of mine mentioned that `>= 1.6` is required.
