### PR TITLE
Add multiple search paths for vim executable

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -62,18 +62,25 @@ endfunction
 function! dispatch#vim_executable() abort
   if !exists('s:vim')
     if has('win32')
-      let root = fnamemodify($VIMRUNTIME, ':8') . dispatch#slash()
+      let roots = [fnamemodify($VIMRUNTIME, ':8') . dispatch#slash(),
+                  \ fnamemodify($VIM, ':8') . dispatch#slash()]
     elseif has('gui_macvim')
-      let root = fnamemodify($VIM, ':h:h') . '/MacOS/'
+      let roots = [fnamemodify($VIM, ':h:h') . '/MacOS/']
     else
-      let root = fnamemodify($VIM, ':h:h') . '/bin/'
+      let roots = [fnamemodify($VIM, ':h:h') . '/bin/']
     endif
-    if executable(root . v:progname)
-      let s:vim = root . v:progname
-    elseif executable(v:progname)
-      let s:vim = v:progname
-    else
-      let s:vim = 'vim'
+    for root in roots
+      if executable(root . v:progname)
+        let s:vim = root . v:progname
+        break
+      endif
+    endfor
+    if !exists('s:vim')
+      if executable(v:progname)
+        let s:vim = v:progname
+      else
+        let s:vim = 'vim'
+      endif
     endif
   endif
   return s:vim


### PR DESCRIPTION
Adds support for [version independent windows installations](http://vim.wikia.com/wiki/Version_independent_installation_of_Vim_on_Windows), could be useful on other systems too.
