### PR TITLE
Added custom callback for compile_command

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -253,7 +253,7 @@ if !exists('s:makes')
   let s:files = {}
 endif
 
-function! dispatch#compile_command(bang, args) abort
+function! dispatch#compile_command(bang, args, ...) abort
   if !empty(a:args)
     let args = a:args
   else
@@ -296,6 +296,8 @@ function! dispatch#compile_command(bang, args) abort
     endif
     let request.command = args
   endif
+
+  let request.callback = a:0 >= 1 ? a:1 : "dispatch#default_callback"
 
   if empty(request.compiler)
     unlet request.compiler
@@ -395,6 +397,13 @@ function! dispatch#completed(request) abort
   return get(s:request(a:request), 'completed', 0)
 endfunction
 
+function! dispatch#default_callback(request) abort
+  if !a:request.background
+    call s:cgetfile(a:request, 0, 0)
+    redraw
+  endif
+endfunction
+
 function! dispatch#complete(file, ...) abort
   if !dispatch#completed(a:file)
     let request = s:request(a:file)
@@ -406,9 +415,8 @@ function! dispatch#complete(file, ...) abort
         echo 'Finished :Dispatch' request.command
       endif
     endif
-    if !request.background
-      call s:cgetfile(request, 0, 0)
-      redraw
+    if has_key(request, 'callback') && !empty(request.callback)
+      exec 'call '.request.callback.'(request)'
     endif
   endif
   return ''


### PR DESCRIPTION
Adds an optional callback parameter to `dispatch#compile_command`. If this parameter is not present, it defaults to the old behaviour (calling `s:cgetfile` if this was a foreground request), but this allows library users to add custom behaviour (e.g. show quickfix after background requests are done, open the location list rather than the quickfix list). 

This should make vim-dispatch more flexible for use by other plugins (see #47, [LaTeX-Box#106](https://github.com/LaTeX-Box-Team/LaTeX-Box/issues/106) or [synctastic#699](https://github.com/scrooloose/syntastic/issues/699)), but doesn't break current APIs.
