### PR TITLE
make s:dispatch global so i can use it in my on plugin

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -148,7 +148,7 @@ function! s:set_current_compiler(name)
   endif
 endfunction
 
-function! s:dispatch(request) abort
+function! dispatch#dispatch(request) abort
   for handler in g:dispatch_handlers
     let response = call('dispatch#'.handler.'#handle', [a:request])
     if !empty(response)
@@ -187,7 +187,7 @@ function! dispatch#start(command, ...) abort
         \ 'expanded': dispatch#expand(command),
         \ 'title': title,
         \ }, a:0 ? a:1 : {})
-  if !s:dispatch(request)
+  if !dispatch#dispatch(request)
     execute '!' . request.command
   endif
   return ''
@@ -314,7 +314,7 @@ function! dispatch#compile_command(bang, args) abort
   let &errorfile = request.file
 
   cclose
-  if !s:dispatch(request)
+  if !dispatch#dispatch(request)
     execute '!'.request.command dispatch#shellpipe(request.file)
     call dispatch#complete(request.id, 'quiet')
   endif


### PR DESCRIPTION
renaming s:dispatch to dispatch#dispatch so i can create custom dispatch#create_commands in other plugins, as an alternative until we figure out how to allow generic callbacks
