### PR TITLE
Wrap returned command with shellxquote on Windows

### DIFF
--- a/autoload/dispatch/windows.vim
+++ b/autoload/dispatch/windows.vim
@@ -10,9 +10,9 @@ function! s:escape(str)
     return '"' . substitute(a:str, '"', '""', 'g') . '"'
   else
     let esc = exists('+shellxescape') ? &shellxescape : '"&|<>()@^'
-    return &shellquote .
+    return &shellxquote .
           \ substitute(a:str, '['.esc.']', '^&', 'g') .
-          \ get({'(': ')', '"(': ')"'}, &shellquote, &shellquote)
+          \ get({'(': ')', '"(': ')"'}, &shellxquote, &shellxquote)
   endif
 endfunction
 


### PR DESCRIPTION
Closes #62

On Win32 gVim, shellquote is null, where shellxquote is populated with
"(".  Wrap returned command with shellxquote, instead of shellquote.
