### PR TITLE
[wip] Added support to screen foreground, fixes #83

### DIFF
--- a/autoload/dispatch/screen.vim
+++ b/autoload/dispatch/screen.vim
@@ -11,6 +11,8 @@ function! dispatch#screen#handle(request) abort
   if empty($STY) || !executable('screen')
     return 0
   endif
+  call dispatch#screen#poll()
+
   if a:request.action ==# 'make'
     if !get(a:request, 'background', 0) && empty(v:servername) && !empty(s:waiting)
 	  return 0
@@ -59,8 +61,7 @@ function! dispatch#screen#poll() abort
     return
   endif
 
-  let pid = dispatch#pid(s:waiting)
-  if !pid
+  if !dispatch#pid(s:waiting)
     let request = s:waiting
     let s:waiting = {}
     call dispatch#complete(request)

--- a/autoload/dispatch/screen.vim
+++ b/autoload/dispatch/screen.vim
@@ -32,14 +32,10 @@ function! dispatch#screen#spawn(command, request) abort
         \ dispatch#set_title(a:request), a:command, teardown))
 
   if a:request.background
-    let command = command
+    call system(command)
   else
-    let command = 'screen -X eval "split" "focus down" "resize 10" "' . substitute(command, '"', '\"', '') . '" "focus up"'
-  endif
-
-  call system(command)
-
-  if !a:request.background
+    let command = 'screen -X eval "split" "focus down" "resize 10" "' . escape(command, '"') . '" "focus up"'
+    call system(command)
     let s:waiting = a:request
   endif
 

--- a/autoload/dispatch/screen.vim
+++ b/autoload/dispatch/screen.vim
@@ -12,6 +12,9 @@ function! dispatch#screen#handle(request) abort
     return 0
   endif
   if a:request.action ==# 'make'
+    if !get(a:request, 'background', 0) && empty(v:servername) && !empty(s:waiting)
+	  return 0
+    endif
     return dispatch#screen#spawn(dispatch#prepare_make(a:request), a:request)
   elseif a:request.action ==# 'start'
     return dispatch#screen#spawn(dispatch#prepare_start(a:request), a:request)


### PR DESCRIPTION
Im trying to add support to screen foreground execution using splits. This is work done until now, but getting some errors, like:

```
:Dispatch sleep 2
```

Running this open the split but this errors appears on vim:

```
Error detected while processing function dispatch#compile_command..<SNR>57_dispatch..dispatch#screen#handle..dispatch#screen#spawn:
line   22:
E484: Can't open file /tmp/vu7hFCf/2
```

The file `/tmp/vu7hFCf/2` is the file on the `request.file` argument to `dispatch#screen#handle()` call.
