### PR TITLE
Strip out ^[[2K and ^[[0G in tmux output

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -58,7 +58,7 @@ function! dispatch#tmux#make(request) abort
   elseif uname ==# 'Linux'
     let filter .= ' -u'
   endif
-  let filter .= " -e \"s/\r$//\" -e \"s/.*\r//\" -e \"s/\e\\[K//g\" -e \"s/\e\\[[0-9;]*m//g\" > ".a:request.file
+  let filter .= " -e \"s/\r$//\" -e \"s/.*\r//\" -e \"s/\e\\[K//g\" -e \"s/.*\e\\[2K\e\\[0G//g\" -e \"s/\e\\[[0-9;]*m//g\" > ".a:request.file
   call system('tmux ' . cmd . '|tee ' . s:make_pane .
         \ (pipepane ? '|xargs -I {} tmux pipe-pane -t {} '.shellescape(filter) : ''))
 


### PR DESCRIPTION
`^[[2K` is an escape code, which means "erase entire current line" and should not
be included in the output. `^[[0G` is another escape code. I could not find out
its meaning, but it clutters up the output as well. See the screenshot for an "before" example.

![example](https://cloud.githubusercontent.com/assets/2971615/3888764/0b3d8ed6-2204-11e4-8621-ebb384b04587.png)
