### PR TITLE
Add an option to always open quickfix after completion

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -627,8 +627,9 @@ function! dispatch#complete(file) abort
     let request = s:request(a:file)
     let request.completed = 1
     echo 'Finished:' request.command
+    let copen = get(g:, 'dispatch_always_copen', 0)
     if !request.background
-      call s:cgetfile(request, 0, 0)
+      call s:cgetfile(request, 0, copen)
       redraw
     endif
   endif


### PR DESCRIPTION
But I'm not sure if this is a bug actually, since https://github.com/tpope/vim-dispatch/commit/b0ce64720d11f11239e48efe01a101b93f5bfa70
Probably we need just`call s:cgetfile(request, 0, 1)`here.
