### PR TITLE
Basic support of vimproc

### DIFF
--- a/autoload/dispatch/vimproc.vim
+++ b/autoload/dispatch/vimproc.vim
@@ -1,0 +1,33 @@
+" dispatch.vim vimproc strategy
+
+if exists('g:autoloaded_dispatch_vimproc')
+  finish
+endif
+let g:autoloaded_dispatch_vimproc = 1
+
+function! dispatch#vimproc#handle(request) abort
+  if !exists('g:loaded_vimproc')
+    return 0
+  endif
+
+  if a:request.action ==# 'make'
+    let command = dispatch#prepare_make(a:request)
+  elseif a:request.action ==# 'start'
+    let command = dispatch#prepare_start(a:request)
+  endif
+
+  if &shellredir =~# '%s'
+    let redir = printf(&shellredir, '/dev/null')
+  else
+    let redir = &shellredir . ' ' . '/dev/null'
+  endif
+
+  let process = vimproc#popen2(&shell.' '.&shellcmdflag.' '.shellescape(command).redir.' &')
+  let [cond, status] = process.waitpid()
+
+  return !status
+endfunction
+
+function! dispatch#vimproc#activate(pid) abort
+  return 0
+endfunction

--- a/doc/dispatch.txt
+++ b/doc/dispatch.txt
@@ -137,6 +137,11 @@ This strategy fires if you're in MacVim with at least one iTerm window open,
 or if Vim is running in iTerm itself.  In the latter case, you can't use it
 for foreground |:Make| invocations.
 
+Vimproc ~
+
+This strategy works if you have vimproc.vim installed. It spawns process
+into background so you can't see it, though you can check it with |:Copen|.
+
 X11 ~
 
 Uses $TERMINAL, x-terminal-emulator, or xterm.  Used for |:Start| and, if

--- a/plugin/dispatch.vim
+++ b/plugin/dispatch.vim
@@ -35,6 +35,7 @@ if !exists('g:dispatch_handlers')
         \ 'screen',
         \ 'windows',
         \ 'iterm',
+        \ 'vimproc',
         \ 'x11',
         \ 'headless',
         \ ]


### PR DESCRIPTION
Related to #33

Since recent versions of iTerm have totally different AppleScript support and dispatch stopped working for me, I've written a simple strategy for [vimproc](https://github.com/Shougo/vimproc.vim).

It currently just forks process into background without blocking Vim.
