### PR TITLE
Vimshell strategy

### DIFF
--- a/autoload/dispatch/vimshell.vim
+++ b/autoload/dispatch/vimshell.vim
@@ -1,0 +1,92 @@
+" dispatch.vim vimshell strategy
+
+if exists('g:autoloaded_dispatch_vimshell')
+  finish
+endif
+let g:autoloaded_dispatch_vimshell = 1
+
+function! dispatch#vimshell#handle(request) abort
+  if !exists('g:loaded_vimshell') || a:request.background
+    return 0
+  endif
+
+  let s:tempfile = a:request.file
+  let s:action = a:request.action
+
+  let vimshell_context = {
+        \ 'buffer_name': 'vim-dispatch',
+        \ 'create': 1,
+        \ 'prompt': '$ '
+        \ }
+
+  if s:action ==# 'make'
+    let vimshell_context.split = 1
+    let vimshell_context.split_command = 'botright split | resize 10'
+  elseif s:action ==# 'start'
+    let vimshell_context.tab = 1
+    execute 'tabnew'
+  endif
+
+  call vimshell#init#_start(a:request.directory, vimshell_context)
+  call vimshell#hook#add('preparse', 'dispatch', 'dispatch#vimshell#preparse')
+
+  if s:action ==# 'make'
+    call vimshell#hook#add('postexit', 'dispatch', 'dispatch#vimshell#postexit')
+    execute 'wincmd p'
+  endif
+
+  let a:request.pid = bufnr('%')
+  let s:pid = a:request.pid
+
+  call vimshell#interactive#send(a:request.expanded)
+
+  return 1
+endfunction
+
+function! dispatch#vimshell#activate(pid) abort
+  for tabpage in range(tabpagenr('$'))
+    let tabnumber = tabpage + 1
+    for bufnr in tabpagebuflist(tabnumber)
+      if bufnr ==# a:pid
+        execute 'tabnext '.tabnumber
+        execute bufwinnr(bufnr).'wincmd w'
+
+        return 1
+      endif
+    endfor
+  endfor
+endfunction
+
+function! dispatch#vimshell#running(pid) abort
+  return bufexists(str2nr(a:pid))
+endfunction
+
+function! dispatch#vimshell#preparse(...) abort
+  call vimshell#hook#remove('preparse', 'dispatch')
+
+  setlocal norelativenumber
+  setlocal nonumber
+
+  let command = a:1
+
+  if s:action ==# 'make'
+    let s:updatetime = &updatetime
+    let &updatetime = 100
+    let command .= ' '.&shellpipe.' '.s:tempfile
+  endif
+
+  return 'clear; '.
+        \ 'echo '.s:pid.' > '.s:tempfile.'.pid; '.
+        \ &shell.' '.&shellcmdflag.' '.vimproc#shellescape(command).
+        \ '; exit'
+endfunction
+
+function! dispatch#vimshell#postexit(...) abort
+  call vimshell#hook#remove('postexit', 'dispatch')
+  let &updatetime = s:updatetime
+
+  call system(&shell.' '.&shellcmdflag.' '.
+        \ shellescape("perl -pi.bak -e 's/\x1b.*?[mGKH]//g' ".s:tempfile))
+  call dispatch#copen(0)
+  execute 'wincmd p'
+endfunction

--- a/doc/dispatch.txt
+++ b/doc/dispatch.txt
@@ -137,6 +137,13 @@ This strategy fires if you're in MacVim with at least one iTerm window open,
 or if Vim is running in iTerm itself.  In the latter case, you can't use it
 for foreground |:Make| invocations.
 
+Vimshell ~
+
+Can be used if you have |vimshell.vim| installed.  Foreground spawns new
+unfocused vimshell buffer which shows you command output (almost) in real
+time.  It is also possible to start interactive commands (e.g. irb) but
+prefer using |:Start| for this.  Background builds are not supported.
+
 X11 ~
 
 Uses $TERMINAL, x-terminal-emulator, or xterm.  Used for |:Start| and, if

--- a/plugin/dispatch.vim
+++ b/plugin/dispatch.vim
@@ -35,6 +35,7 @@ if !exists('g:dispatch_handlers')
         \ 'screen',
         \ 'windows',
         \ 'iterm',
+        \ 'vimshell',
         \ 'x11',
         \ 'headless',
         \ ]


### PR DESCRIPTION
Strategy on top of [vimshell](https://github.com/Shougo/vimshell.vim).

Brings the following on the table (especially cool for GUI):

1. ANSI color support.
2. Allows using interactive commands (e.g. irb) and sending SIGINT (with `<C-c>`).
3. Shows command output while it's running.
4. A lot more that vimshell allows to do.

The following also concern me:

1. ~~No pid (is this a problem?).~~ Pid is now buffer number.
2. `dispatch#copen(0)` is called directly in `postexit` hook. I suppose it is not the best way to do that.
3. No support for background builds because hooks are not trigger for hidden vimshell buffer.
4. ~~No `dispatch#vimshell#activate()` at the moment but I think it can be easily added, I just need to understand the expected behaviour.~~ Activate works correctly.
5. Changes `updatetime` to low values while process is running. Vimshell adds autocmd on `CursorHold,CursorHoldI` to update output when vimshell buffer is not focused. Low `updatetime` works fine for me in GUI, but in Terminal this makes cursor blink like a crazy one. Any ideas on how to improve that?
6. Command exit code is not correct (it uses exit code from `tee`). I believe it is not really important and not all strategies implement that correctly but it can be fixed with a bit more bash.

I have implemented my own function to strip color codes from piped file with perl, but I know tmux strategy does the same, so it might make sense to share to code.