### PR TITLE
Fixed #108 : E484 when used on Windows GVim with cygwin shell

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -581,7 +581,11 @@ function! s:running(pid) abort
   if !a:pid
     return 0
   elseif has('win32')
-    return system('tasklist /fi "pid eq '.a:pid.'"') =~# '==='
+    let tasklist_cmd = 'tasklist /fi "pid eq '.a:pid.'"'
+    if &shellxquote ==# '"'
+      let tasklist_cmd = substitute(tasklist_cmd, '"', "'", "g")
+    endif
+    return system(tasklist_cmd) =~# '==='
   else
     call system('kill -0 '.a:pid)
     return !v:shell_error

--- a/autoload/dispatch/windows.vim
+++ b/autoload/dispatch/windows.vim
@@ -71,9 +71,14 @@ function! dispatch#windows#start(request) abort
 endfunction
 
 function! dispatch#windows#activate(pid) abort
-  if system('tasklist /fi "pid eq '.a:pid.'"') !~# '==='
+  let tasklist_cmd = 'tasklist /fi "pid eq '.a:pid.'"'
+  if &shellxquote ==# '"'
+    let tasklist_cmd = substitute(tasklist_cmd, '"', "'", "g")
+  endif
+  if system(tasklist_cmd) !~# '==='
     return 0
   endif
+
   if !exists('s:activator')
     let s:activator = tempname().'.vbs'
     call writefile(['WScript.CreateObject("WScript.Shell").AppActivate(WScript.Arguments(0))'], s:activator)


### PR DESCRIPTION
On Windows gvim, if the shell is set to cygwin shell or msys shell, these two `system()` call would cause the shell misinterpret the quoting of the command. Thus, I suggest to escape double quotes when these shells are used, while keeping the original command when the default `cmd` shell is used.