### PR TITLE
Use `echomsg`/`echoerr` for completion status

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -789,11 +789,11 @@ function! dispatch#complete(file) abort
       let status = -1
     endtry
     if status > 0
-      echo 'Failed:' request.command
+      echoerr 'Failed:' request.command
     elseif status == 0
-      echo 'Succeeded:' request.command
+      echomsg 'Succeeded:' request.command
     else
-      echo 'Finished:' request.command
+      echomsg 'Finished:' request.command
     endif
     if !request.background
       call s:cgetfile(request, 0, 0)


### PR DESCRIPTION
Sometimes I run a test suite, then check my phone or grab a coffee for
a couple minutes. If the suite passes, then when I come back I look at
vim and there's nothing there - so I second guess myself on whether I
actually ran the suite in the first place. Having some sort of
persistent message no matter what happens when a :Dispatch is run would
be nice.