### PR TITLE
Allow default error format to be customised

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -539,7 +539,7 @@ function! dispatch#compile_command(bang, args, count) abort
   call extend(request, {
         \ 'action': 'make',
         \ 'background': a:bang,
-        \ 'format': '%+I%.%#'
+        \ 'format': g:dispatch_format
         \ }, 'keep')
 
   if executable ==# '_'

--- a/plugin/dispatch.vim
+++ b/plugin/dispatch.vim
@@ -41,3 +41,7 @@ if !exists('g:dispatch_handlers')
         \ 'headless',
         \ ]
 endif
+
+if !exists('g:dispatch_format')
+  let g:dispatch_format = '%+I%.%#'
+endif


### PR DESCRIPTION
I'm personally using this to change the error format to `'%f:%l: %m,%+I%.%#'`. Currently output like this isn't parsed:

```
path/to/file.text:42: TODO: fix stuff
```