### PR TITLE
[RFC] Emit user event after opening quickfix window

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -854,6 +854,7 @@ function! s:open_quickfix(request, copen) abort
   if &buftype ==# 'quickfix' && !was_qf && a:copen != 1
     wincmd p
   endif
+  silent doautocmd User dispatch-quickfix
   for winnr in range(1, winnr('$'))
     if getwinvar(winnr, '&buftype') ==# 'quickfix'
       call setwinvar(winnr, 'quickfix_title', ':' . a:request.expanded)


### PR DESCRIPTION
Hi,

I found a few `:doautocmd` in the code, but they all fire before the quickfix window is opened. For other plugins that use dispatch and handle the quickfix window theirselves, it would be nice to have something like this.

What do you think?