### PR TITLE
Support for legacy %< format in makeprg string

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -39,7 +39,7 @@ function! dispatch#shellescape(...) abort
   return join(args, ' ')
 endfunction
 
-let s:flags = '\%(:[p8~.htre]\|:g\=s\(.\).\{-\}\1.\{-\}\1\)*'
+let s:flags = '<\=\%(:[p8~.htre]\|:g\=s\(.\).\{-\}\1.\{-\}\1\)*'
 let s:expandable = '\\*\%(<\w\+>\|%\|#\d*\)' . s:flags
 function! dispatch#expand(string) abort
   return substitute(a:string, s:expandable, '\=s:expand(submatch(0))', 'g')


### PR DESCRIPTION
Although %< exists for backward compatibility reasons (see :help %<), it would be nice to support it as well.