### PR TITLE
Allow configure size of a quickfix and a tmux panel

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -850,7 +850,8 @@ endfunction
 
 function! s:open_quickfix(request, copen) abort
   let was_qf = &buftype ==# 'quickfix'
-  execute 'botright' (a:copen ? 'copen' : 'cwindow')
+  let height = get(g:, 'dispatch_quickfix_height', 10)
+  execute 'botright' (a:copen ? 'copen'.height : 'cwindow'.height)
   if &buftype ==# 'quickfix' && !was_qf && a:copen != 1
     wincmd p
   endif

--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -41,12 +41,13 @@ function! dispatch#tmux#make(request) abort
         \ (pipepane ? [a:request.expanded . '; echo $? > ' . a:request.file . '.complete'] : [])))
 
   let title = shellescape(get(a:request, 'title', get(a:request, 'compiler', 'make')))
+  let height = get(g:, 'dispatch_tmux_height', 10)
   if get(a:request, 'background', 0)
     let cmd = 'new-window -d -n '.title
   elseif has('gui_running') || empty($TMUX) || (!empty(''.session) && session !=# system('tmux display-message -p "#S"')[0:-2])
     let cmd = 'new-window -n '.title
   else
-    let cmd = 'split-window -l 10 -d'
+    let cmd = 'split-window -l '.height.' -d'
   endif
 
   let cmd .= ' ' . dispatch#shellescape('-P', '-t', session.':', 'exec ' . script)


### PR DESCRIPTION
Adds two configuration options `g:dispatch_quickfix_height` and `g:dispatch_tmux_height`.
By default each is 10.