### PR TITLE
s:dispatch: shorten displayed message to avoid hit-enter prompt

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -375,12 +375,14 @@ function! s:dispatch(request) abort
       redraw
       let msg = ':!'
       let suffix = s:postfix(a:request)
+      let suffix_len = len(substitute(suffix, '.', '.', 'g'))
       let cmd = a:request.expanded
+      let cmd_len = len(substitute(cmd, '.', '.', 'g'))
       " NOTE: the extra "-13" is required to avoid the hit-enter, although
       " it's displayed on a single line already?!
       let max_cmd_len = (&cmdheight * &columns)-2-len(suffix)-13
-      if len(cmd) > max_cmd_len
-        let msg .= cmd[0:max_cmd_len-2] . '…'
+      if cmd_len > max_cmd_len
+        let msg .= '<' . matchstr(cmd, '\v.{'.(max_cmd_len - 1).'}$')
       else
         let msg .= cmd
       endif

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -381,7 +381,7 @@ function! s:dispatch(request) abort
       let max_cmd_len = (&cmdheight * &columns) - 2 - suffix_len - 2
 
       if has('cmdline_info')
-        let last_has_status = (&statusline == 2 || (&statusline == 1 && winnr('$') != 1))
+        let last_has_status = (&laststatus == 2 || (&laststatus == 1 && winnr('$') != 1))
 
         if &ruler && !last_has_status
           if empty(&rulerformat)

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -376,9 +376,9 @@ function! s:dispatch(request) abort
       let msg = ':!'
       let suffix = s:postfix(a:request)
       let cmd = a:request.expanded
-      " NOTE: the extra "-12" is required to avoid the hit-enter, although
+      " NOTE: the extra "-13" is required to avoid the hit-enter, although
       " it's displayed on a single line already?!
-      let max_cmd_len = (&cmdheight * &columns)-2-len(suffix)-12
+      let max_cmd_len = (&cmdheight * &columns)-2-len(suffix)-13
       if len(cmd) > max_cmd_len
         let msg .= cmd[0:max_cmd_len-2] . '…'
       else

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -372,15 +372,24 @@ function! s:dispatch(request) abort
     let response = call('dispatch#'.handler.'#handle', [a:request])
     if !empty(response)
       let a:request.handler = handler
+
+      " Display command, avoiding hit-enter prompt.
       redraw
       let msg = ':!'
       let suffix = s:postfix(a:request)
       let suffix_len = len(substitute(suffix, '.', '.', 'g'))
+      let max_cmd_len = (&cmdheight * &columns) - 2 - suffix_len - 2
+      if &ruler || &showcmd
+        if &ruler
+          let max_cmd_len -= 17  " Default, might be dynamic.
+        endif
+        if &showcmd
+          let max_cmd_len -= 10
+        endif
+        let max_cmd_len -= 1
+      endif
       let cmd = a:request.expanded
       let cmd_len = len(substitute(cmd, '.', '.', 'g'))
-      " NOTE: the extra "-13" is required to avoid the hit-enter, although
-      " it's displayed on a single line already?!
-      let max_cmd_len = (&cmdheight * &columns)-2-len(suffix)-13
       if cmd_len > max_cmd_len
         let msg .= '<' . matchstr(cmd, '\v.{'.(max_cmd_len - 1).'}$')
       else

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -379,14 +379,29 @@ function! s:dispatch(request) abort
       let suffix = s:postfix(a:request)
       let suffix_len = len(substitute(suffix, '.', '.', 'g'))
       let max_cmd_len = (&cmdheight * &columns) - 2 - suffix_len - 2
-      if &ruler || &showcmd
-        if &ruler
-          let max_cmd_len -= 17  " Default, might be dynamic.
+
+      if has('cmdline_info')
+        let last_has_status = (&statusline == 2 || (&statusline == 1 && winnr('$') != 1))
+
+        if &ruler && !last_has_status
+          if empty(&rulerformat)
+            " Default ruler is 17 chars wide.
+            let max_cmd_len -= 17
+          elseif exists('g:rulerwidth')
+            " User specified width of custom ruler.
+            let max_cmd_len -= g:rulerwidth
+          else
+            " Don't know width of custom ruler, make a conservative guess.
+            let max_cmd_len -= &columns / 2
+          endif
+          let max_cmd_len -= 1
         endif
         if &showcmd
           let max_cmd_len -= 10
+          if !&ruler || last_has_status
+            let max_cmd_len -= 1
+          endif
         endif
-        let max_cmd_len -= 1
       endif
       let cmd = a:request.expanded
       let cmd_len = len(substitute(cmd, '.', '.', 'g'))

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -373,7 +373,19 @@ function! s:dispatch(request) abort
     if !empty(response)
       let a:request.handler = handler
       redraw
-      echo ':!'.a:request.expanded s:postfix(a:request)
+      let msg = ':!'
+      let suffix = s:postfix(a:request)
+      let cmd = a:request.expanded
+      " NOTE: the extra "-12" is required to avoid the hit-enter, although
+      " it's displayed on a single line already?!
+      let max_cmd_len = (&cmdheight * &columns)-2-len(suffix)-12
+      if len(cmd) > max_cmd_len
+        let msg .= cmd[0:max_cmd_len-2] . '…'
+      else
+        let msg .= cmd
+      endif
+      let msg .= ' '.suffix
+      echo msg
       return response
     endif
   endfor


### PR DESCRIPTION
Fixes https://github.com/tpope/vim-dispatch/issues/166.
