### PR TITLE
iTerm 3 compatability

### DIFF
--- a/autoload/dispatch/iterm.vim
+++ b/autoload/dispatch/iterm.vim
@@ -20,7 +20,37 @@ function! dispatch#iterm#handle(request) abort
   endif
 endfunction
 
+function! dispatch#iterm#is_modern_version() abort
+  return s:osascript(
+      \ 'on modernversion(version)',
+      \   'set olddelimiters to AppleScript''s text item delimiters',
+      \   'set AppleScript''s text item delimiters to "."',
+      \   'set thearray to every text item of version',
+      \   'set AppleScript''s text item delimiters to olddelimiters',
+      \   'set major to item 1 of thearray',
+      \   'set minor to item 2 of thearray',
+      \   'set veryminor to item 3 of thearray',
+      \   'if major < 2 then return false',
+      \   'if major > 2 then return true',
+      \   'if minor < 9 then return false',
+      \   'if minor > 9 then return true',
+      \   'if veryminor < 20140903 then return false',
+      \   'return true',
+      \ 'end modernversion',
+      \ 'tell application "iTerm"',
+      \   'if not my modernversion(version) then error',
+      \ 'end tell')
+endfunction
+
 function! dispatch#iterm#spawn(command, request, activate) abort
+  if dispatch#iterm#is_modern_version()
+    return dispatch#iterm#spawn3(a:command, a:request, a:activate)
+  else
+    return dispatch#iterm#spawn2(a:command, a:request, a:activate)
+  endif
+endfunction
+
+function! dispatch#iterm#spawn2(command, request, activate) abort
   let script = dispatch#isolate([], dispatch#set_title(a:request), a:command)
   return s:osascript(
       \ 'if application "iTerm" is not running',
@@ -40,7 +70,35 @@ function! dispatch#iterm#spawn(command, request, activate) abort
       \ 'end tell')
 endfunction
 
+function! dispatch#iterm#spawn3(command, request, activate) abort
+  let script = dispatch#isolate([], dispatch#set_title(a:request), a:command)
+  return s:osascript(
+      \ 'if application "iTerm" is not running',
+      \   'error',
+      \ 'end if') && s:osascript(
+      \ 'tell application "iTerm"',
+      \   'tell the current window',
+      \     'set oldtab to the current tab',
+      \     'set newtab to (create tab with default profile command ' . s:escape(script) . ')',
+      \     'tell current session of newtab',
+      \       'set name to ' . s:escape(a:request.title),
+      \       'set title to ' . s:escape(a:request.command),
+      \     'end tell',
+      \     a:request.background ? 'select oldtab' : '',
+      \   'end tell',
+      \   a:activate ? 'activate' : '',
+      \ 'end tell')
+endfunction
+
 function! dispatch#iterm#activate(pid) abort
+  if dispatch#iterm#is_modern_version()
+    return dispatch#iterm#activate3(pid)
+  else
+    return dispatch#iterm#activate2(pid)
+  endif
+endfunction
+
+function! dispatch#iterm#activate2(pid) abort
   let tty = matchstr(system('ps -p '.a:pid), 'tty\S\+')
   if !empty(tty)
     return s:osascript(
@@ -51,6 +109,27 @@ function! dispatch#iterm#activate(pid) abort
         \   'activate',
         \   'tell the current terminal',
         \      'select session id "/dev/'.tty.'"',
+        \   'end tell',
+        \ 'end tell')
+  endif
+endfunction
+
+function! dispatch#iterm#activate3(pid) abort
+  let tty = matchstr(system('ps -p '.a:pid), 'tty\S\+')
+  if !empty(tty)
+    return s:osascript(
+        \ 'if application "iTerm" is not running',
+        \   'error',
+        \ 'end if') && s:osascript(
+        \ 'tell application "iTerm"',
+        \   'activate',
+        \   'tell the current window',
+        \     'repeat with atab in tabs',
+        \       'repeat with asession in sessions',
+        \         'if (tty) = ' . tty,
+        \         'select atab',
+        \       'end repeat',
+        \     'end repeat',
         \   'end tell',
         \ 'end tell')
   endif


### PR DESCRIPTION
iTerm 3 introduced breaking changes to the AppleScript api, mentioned
here https://www.iterm2.com/version3.html and here
https://www.iterm2.com/documentation-scripting.html. This allows the
iTerm dispatcher to work with either the version 2 or version 3 api. I wasn't
sure how activate should be triggered, so I am not entirely sure that the version 3
activate script is working, but would be happy to test it with a little guidance.
