### PR TITLE
Strip control characters from Ack output under tmux

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -67,6 +67,7 @@ function! dispatch#tmux#make(request) abort
   let filter .= " -e \"s/\r$//\" -e \"s/.*\r//\""
   let filter .= " -e \"s/\e\\[K//g\" "
   let filter .= " -e \"s/.*\e\\[2K\e\\[0G//g\""
+  let filter .= " -e \"s/.*\e\\[?25h\e\\[0G//g\""
   let filter .= " -e \"s/\e\\[[0-9;]*m//g\""
   let filter .= " -e \"s/\017//g\""
   let filter .= " > " . a:request.file . ""


### PR DESCRIPTION
I was seeing some control characters appearing in the output from [vim-ack](https://github.com/mileszs/ack.vim) when running under dispatch through tmux:

![screenshot 2016-07-14 09 14 35](https://cloud.githubusercontent.com/assets/145/16833027/3e9b9e74-49a5-11e6-943c-f60325a03936.png)

I couldn't see anything in the actual ack output when I ran this alone, so I think it must've been introduced somewhere else in the pipeline. The fix is fairly innocuous though.