### PR TITLE
Fix for new iTerm2 API

### DIFF
--- a/autoload/dispatch/iterm.vim
+++ b/autoload/dispatch/iterm.vim
@@ -27,16 +27,17 @@ function! dispatch#iterm#spawn(command, request, activate) abort
       \   'error',
       \ 'end if') && s:osascript(
       \ 'tell application "iTerm"',
-      \   'tell the current terminal',
-      \     'set oldsession to the current session',
-      \     'tell (make new session)',
-      \       'set name to ' . s:escape(a:request.title),
-      \       'set title to ' . s:escape(a:request.command),
-      \       'exec command ' . s:escape(script),
-      \       a:request.background ? 'select oldsession' : '',
+      \   'tell current window',
+      \     'set newTab to (create tab with default profile)',
+      \     'tell application "MacVim"',
+      \       'activate',
       \     'end tell',
-      \   'end tell',
-      \   a:activate ? 'activate' : '',
+      \     'tell current session',
+      \       'set name to ' . s:escape(a:request.title),
+      \       'set title to ' . s:escape(a:request.title),
+      \       'write text ' . s:escape(script) . '; exit',
+      \       'end tell',
+      \     'end tell',
       \ 'end tell')
 endfunction
 
@@ -48,7 +49,6 @@ function! dispatch#iterm#activate(pid) abort
         \   'error',
         \ 'end if') && s:osascript(
         \ 'tell application "iTerm"',
-        \   'activate',
         \   'tell the current terminal',
         \      'select session id "/dev/'.tty.'"',
         \   'end tell',
@@ -57,7 +57,8 @@ function! dispatch#iterm#activate(pid) abort
 endfunction
 
 function! s:osascript(...) abort
-  call system('osascript'.join(map(copy(a:000), '" -e ".shellescape(v:val)'), ''))
+  let args = join(map(copy(a:000), '" -e ".shellescape(v:val)'), '')
+  call system('osascript'. args)
   return !v:shell_error
 endfunction
 


### PR DESCRIPTION
Tested with ITerm2 Build 3.0.4.

Based on the work of @chemzqm in issue #160. I made some changes on using the original script generated by Dispatch.vim rather than the fish script. So Dispatch.vim could receive the completion message correctly.