### PR TITLE
Fix documentation for the :Dispatch command

### DIFF
--- a/doc/dispatch.txt
+++ b/doc/dispatch.txt
@@ -36,8 +36,8 @@ COMMANDS                                        *dispatch-commands*
                                                 *dispatch-:Dispatch*
 :Dispatch[!] [options] {program} [arguments]
                         Find a compiler plugin that sets 'makeprg' to
-                        {command} and use its 'errorformat' to dispatch a
-                        |:Make| for the given {command} and [arguments].  If
+                        {program} and use its 'errorformat' to dispatch a
+                        |:Make| for the given {program} and [arguments].  If
                         no compiler plugin is found, the generic format
                         %+I%.%# is used.
 


### PR DESCRIPTION
In the documentation of `:Dispatch` there is an inconsistency: the
argument name is `{program}`, but in the documentation body there is a
reference to `{command}` which is unclear. This removes the
inconsistency and renames `{command}` to `{program}` in the
documentation body.