### PR TITLE
Add User#DispatchQuickfix, set t:dispatch_quickfix_winnr

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -867,6 +867,16 @@ function! s:open_quickfix(request, copen) abort
       if has_key(a:request, 'compiler')
         call setbufvar(bufnr, 'current_compiler', a:request.compiler)
       endif
+      let t:dispatch_quickfix_winnr = winnr
+      if exists('#User#DispatchQuickfix')
+        try
+          let [save_mls, &modelines] = [&mls, 0]
+          doautocmd User DispatchQuickfix
+        finally
+          let &mls = save_mls
+        endtry
+      endif
+      break
     endif
   endfor
 endfunction


### PR DESCRIPTION
In `s:open_quickfix` a user autocommand is triggered after the quickfix
window has been massaged, which includes setting `w:quickfix_title`.
This has to be done in the end, since it is not available with `au
FileType qf`.

The variable `t:dispatch_quickfix_winnr` is set to inform the user about the
window's number.
