### PR TITLE
Add initial vim jobs strategy

### DIFF
--- a/autoload/dispatch/jobs.vim
+++ b/autoload/dispatch/jobs.vim
@@ -1,0 +1,63 @@
+" dispatch.vim jobs strategy
+
+if exists('g:autoloaded_dispatch_jobs')
+  finish
+endif
+let g:autoloaded_dispatch_jobs = 1
+
+let s:waiting = {}
+
+function! dispatch#jobs#handle(request) abort
+  if !(has('job') && has('channel') && a:request.action ==# 'make')
+    return 0
+  endif
+
+  let channel_id = s:start_make_job(a:request)
+  if empty(channel_id)
+    return 0
+  endif
+
+  let s:waiting[channel_id] = a:request
+  return 1
+endfunction
+
+function! s:start_make_job(request)
+  let command = dispatch#prepare_make(a:request)
+  let job_options = {
+        \ 'close_cb': function('s:CloseCallback'),
+        \ 'exit_cb' : function('s:ExitCallback'),
+        \ 'out_io'  : 'pipe',
+        \ 'err_io'  : 'out',
+        \ 'in_io'   : 'null',
+        \ 'out_mode': 'nl',
+        \ 'err_mode': 'nl'}
+  let job = job_start([&shell, &shellcmdflag, command], job_options)
+  return s:channel_id(job)
+endfunction
+
+function! s:channel_id(job)
+  if job_status(a:job) ==# 'fail'
+    return ''
+  endif
+
+  let channel = job_getchannel(a:job)
+  if string(channel) ==# 'channel fail'
+    return ''
+  endif
+
+  let channel_info = ch_info(channel)
+  return string(channel_info.id)
+endfun
+
+function! s:ExitCallback(job, status)
+  let channel_id = s:channel_id(a:job)
+  if has_key(s:waiting, channel_id)
+    let request = remove(s:waiting, channel_id)
+    call dispatch#complete(request)
+  endif
+endfun
+
+function! s:CloseCallback(channel)
+  " trigger vim calling s:ExitHandler()
+  call job_status(ch_getjob(a:channel))
+endfun

--- a/plugin/dispatch.vim
+++ b/plugin/dispatch.vim
@@ -35,6 +35,7 @@ if !exists('g:dispatch_handlers')
   let g:dispatch_handlers = [
         \ 'tmux',
         \ 'screen',
+        \ 'jobs',
         \ 'windows',
         \ 'iterm',
         \ 'x11',


### PR DESCRIPTION
This is an initial version of a strategy based on vim 8's jobs. I saw the discussion in #188, hence this PR.

I don't think it's ready yet (I haven't even tested it on files with whitespace in them).

This strategy works only for 'make' actions, but maybe it should also have a check if 'background' is true.

Any feedback is appreciated.

Edit: I haven't thought about windows support at all - the strategy uses dispatch#prepare_make() as well as &shell and &shellcmdflag
