### PR TITLE
Propose a setting to disable automatic copen-ing

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -1091,6 +1091,9 @@ endfunction
 function! s:cwindow(request, all, copen) abort
   call s:cgetfile(a:request, a:all)
   let height = get(g:, 'dispatch_quickfix_height', 10)
+  if height <= 0
+    return
+  endif
   let was_qf = s:is_quickfix()
   execute 'botright' (a:copen ? 'copen' : 'cwindow') height
   if !was_qf && s:is_quickfix() && a:copen !=# -2


### PR DESCRIPTION
Propose to extend the meaningful settings for the height of quickfix window with 0, to state that it should not be opened automatically. This is inspired by what happens with `:make`. I find this especially useful when I’m short on screen space (which is quite often).
This PR consists of one real commit, but it’s based on #207 since it modifies related lines.

Edit: changed the commit number to a reference to the PR.