### PR TITLE
Propose a setting to run tmux foreground jobs in a separate window when possible

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -49,12 +49,12 @@ function! dispatch#tmux#make(request) abort
 
   let title = shellescape(get(a:request, 'title', get(a:request, 'compiler', 'make')))
   let height = get(g:, 'dispatch_tmux_height', get(g:, 'dispatch_quickfix_height', 10))
-  if get(a:request, 'background', 0)
+  if get(a:request, 'background', 0) || (height <= 0 && dispatch#has_callback())
     let cmd = 'new-window -d -n '.title
   elseif has('gui_running') || empty($TMUX) || (!empty(''.session) && session !=# system('tmux display-message -p "#S"')[0:-2])
     let cmd = 'new-window -n '.title
   else
-    let cmd = 'split-window -l '.height.' -d'
+    let cmd = 'split-window -l '.(height < 0 ? -height : height).' -d'
   endif
 
   let cmd .= ' ' . dispatch#shellescape('-P', '-t', session.':', 'exec ' . script)


### PR DESCRIPTION
Propose to extend the meaningful settings for the height of the tmux split for foreground jobs with 0, to state that it should be run in a different (background) window when the GUI subsystem is enabled (so that the job will be able to call back when it finishes).
With this setting, one can obtain the same behaviour with tmux than with screen.
I find this especially convenient whenever I use compilers which takes a long time to start and output eventual messages in one go at the end.

This PR consists of one real commit, but it’s based on #208 since it modifies related lines.
I’d be happy to reorganise (and document) all this if there’s a better way.

Edit: changed the commit number to a reference to the PR.