### PR TITLE
Filtering out multiple consecutive \r at line end

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -66,7 +66,7 @@ function! dispatch#tmux#make(request) abort
   elseif uname ==# 'Linux'
     let filter .= ' -u'
   endif
-  let filter .= " -e \"s/\r$//\" -e \"s/.*\r//\""
+  let filter .= " -e \"s/\r\r*$//\" -e \"s/.*\r//\""
   let filter .= " -e \"s/\e\\[K//g\" "
   let filter .= " -e \"s/.*\e\\[2K\e\\[0G//g\""
   let filter .= " -e \"s/.*\e\\[?25h\e\\[0G//g\""


### PR DESCRIPTION
Problem:
When using pdflatex from miktex with cygwin the output from pdflatex is appended by two carriage returns. The last one gets removed by the ` -e \"s/\r$//\"` rule, but the remaining one leads to a (unwanted) removal of the whole line.

Solution:
Remove all consecutive carriage return at the end of the line.