### PR TITLE
Fix `Make` for headless, which currently steals focus

### DIFF
--- a/autoload/dispatch/headless.vim
+++ b/autoload/dispatch/headless.vim
@@ -6,10 +6,13 @@ endif
 let g:autoloaded_dispatch_headless = 1
 
 function! dispatch#headless#handle(request) abort
-  if !a:request.background || &shell !~# 'sh'
+  if &shell !~# 'sh'
     return 0
   endif
   if a:request.action ==# 'make'
+    if !get(a:request, 'background', 0) && empty(v:servername)
+      return 0
+    endif
     let command = dispatch#prepare_make(a:request)
   elseif a:request.action ==# 'start'
     let command = dispatch#prepare_start(a:request)


### PR DESCRIPTION
All strategies for `Make` work as:
- building outside of vim asynchronously, in order to not steal focus
- callback opening the quickfix

Except for the headless strategy, which is a synchronous build, basically a synonym for `make`.


This very simple PR fixes this by allowing the headless Make to be asynchronous, making it more similar to other backends for Make and actually useful between `make` and `Make!`

| command | headless behaviour before | headless behaviour after |
|--|--|--|
| `make` | synchronous, steals focus + open QF | synchronous, steals focus + open QF |
| `Make` | **synchronous, steals focus** + open QF | **asynchronous, hidden** + open QF |
| `Make!` | asynchronous, hidden, no QF | asynchronous, hidden, no QF |