### PR TITLE
X11: pass command as single argument to terminal

### DIFF
--- a/autoload/dispatch/x11.vim
+++ b/autoload/dispatch/x11.vim
@@ -39,7 +39,8 @@ function! dispatch#x11#spawn(terminal, command, request) abort
   if a:request.background || a:request.action ==# 'make'
     let command = 'wmctrl -i -a '.v:windowid . ';' . command
   endif
-  call system(dispatch#shellescape(a:terminal, '-e', &shell, &shellcmdflag, command). ' &')
+  let command = dispatch#shellescape(&shell, &shellcmdflag, command)
+  call system(dispatch#shellescape(a:terminal, '-e', command) . ' &')
   return 1
 endfunction
 


### PR DESCRIPTION
In some terminal emulators, -e takes only a single argument.  In
particular, I ran into problems with the xfce4-terminal; xterm allows
either form.

Testing:
TERMINAL=xfce4-terminal vim +"Spawn yes it works" +q
TERMINAL=xterm vim +"Spawn yes it works" +q

Edit:
In retrospect, I'm not sure this is the best option, as further testing shows that st and the rxvt terminal emulators do not accept a full command line as a single argument. However, xfce4-terminal is not unique in the way it treats -e either: gnome-terminal does the same thing.

Dropping st and (u)rxvt support seems unwise, but for now I'm going to leave this PR open because it would be nice if vim-dispatch worked with my `$TERMINAL`, I just don't think this is the right way to do it.