### PR TITLE
Check request.file.complete for complete state

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -872,7 +872,11 @@ function! dispatch#pid(request) abort
 endfunction
 
 function! dispatch#completed(request) abort
-  return get(s:request(a:request), 'completed', 0)
+  let request = s:request(a:request)
+  if get(request, 'background', 0)
+    return filereadable(request.file . '.complete')
+  endif
+  return get(request, 'completed', 0)
 endfunction
 
 function! dispatch#complete(file) abort
@@ -999,3 +1003,4 @@ function! dispatch#quickfix_init() abort
 endfunction
 
 " }}}1
+

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -1003,4 +1003,3 @@ function! dispatch#quickfix_init() abort
 endfunction
 
 " }}}1
-


### PR DESCRIPTION
I verified that this works well with the following use case:

```vim
augroup python
  autocmd!
  autocmd BufWritePost *.py call <SID>TryTests(1)
  autocmd FileType python nnoremap <buffer> <F8> :<C-U>call <SID>TryTests(0)<CR>
  autocmd FileType python nnoremap <buffer> <F7> :<C-U>Cop<CR>
augroup END

function! s:TryTests(bg)
  if !exists('b:has_test_target')
    let b:has_test_target = filereadable('Makefile')
          \ && match(readfile('Makefile'), 'test:') != -1
  endif
  if b:has_test_target
    let request = dispatch#request()
    " if get(request, 'background', 0)
    "   " background tasks need to be explicitly checked against the system
    "   call system('ps -p ' . get(request, 'pid'))
    " endif
    " if empty(request) || dispatch#completed(request) || v:shell_error
    if empty(request) || dispatch#completed(request)
      let test_command = 'Make'
      if a:bg | let test_command .= '!' | endif
      let test_command .= ' test'
      silent execute test_command
    else
      echom 'Current tests are still running.'
    endif
  endif
endfunction
```

I'm not sure why `request.completed` isn't the source of truth for background tasks; it feels like the fix belongs somewhere upstream, and `dispatch#completed` shouldn't have to change. I haven't dived deep into the code though, so I could be wrong. Either way, I'm curious to know if there's a better approach.