### PR TITLE
Keep the USER environment variable in isolated command

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -318,7 +318,7 @@ function! dispatch#set_title(request) abort
 endfunction
 
 function! dispatch#isolate(request, keep, ...) abort
-  let keep = ['SHELL'] + a:keep
+  let keep = ['SHELL', 'USER'] + a:keep
   let command = ['cd ' . shellescape(getcwd())]
   for line in split(system('env'), "\n")
     let var = matchstr(line, '^\w\+\ze=')


### PR DESCRIPTION
This prevents issues similar to #179 if sections in bashrc/profile
of the default-shell in tmux assume these are available.

There might be a better way around this, changing the tmux configuration to start a non longin shell avoids the issue but that's undesirable for other panes. Not starting a login shell for the dispatch panes would also solve the particular case I ran into.