### PR TITLE
Add xprop fallback for windowid

### DIFF
--- a/autoload/dispatch/x11.vim
+++ b/autoload/dispatch/x11.vim
@@ -5,12 +5,19 @@ if exists('g:autoloaded_dispatch_x11')
 endif
 let g:autoloaded_dispatch_x11 = 1
 
+function! s:windowid()
+  if executable('xprop')
+    return matchstr(system("xprop -root _NET_ACTIVE_WINDOW"), '0x\x\+')
+  endif
+endf
+
 function! dispatch#x11#handle(request) abort
   if $DISPLAY !~# '^:'
     return 0
   endif
+  let windowid = s:windowid()
   if get(a:request, 'background') &&
-        \ (!v:windowid || !executable('wmctrl'))
+        \ (empty(windowid) || !executable('wmctrl'))
     return 0
   endif
   if exists('g:dispatch_terminal_exec')
@@ -23,16 +30,17 @@ function! dispatch#x11#handle(request) abort
     return 0
   endif
   if a:request.action ==# 'start'
-    return dispatch#x11#spawn(terminal, dispatch#prepare_start(a:request), a:request)
+    return dispatch#x11#spawn(terminal, dispatch#prepare_start(a:request), a:request, windowid)
   else
     return 0
   endif
 endfunction
 
-function! dispatch#x11#spawn(terminal, command, request) abort
+function! dispatch#x11#spawn(terminal, command, request, windowid) abort
   let command = dispatch#set_title(a:request) . '; ' . a:command
   if a:request.background
-    let command = 'wmctrl -i -a '.v:windowid . ';' . command
+    let command = 'wmctrl -i -a '. a:windowid . ';' . command
+    echom command
   endif
   call system(a:terminal . ' ' . dispatch#shellescape(&shell, &shellcmdflag, command). ' &')
   return 1


### PR DESCRIPTION
Some popular terminals, e.g. gnome-terminal do not set $WINDOWID.
Additionally, the Neovim TUI does not yet support $WINDOWID.

Fix #277