### PR TITLE
fix blank output in tmux when using fish shell

### DIFF
--- a/autoload/dispatch/tmux.vim
+++ b/autoload/dispatch/tmux.vim
@@ -39,7 +39,7 @@ function! dispatch#tmux#handle(request) abort
 endfunction
 
 function! dispatch#tmux#make(request) abort
-  let pipepane = (&shellpipe ==# '2>&1| tee' || &shellpipe ==# '|& tee') && &shell !~# 'fish'
+  let pipepane = (&shellpipe ==# '2>&1| tee' || &shellpipe ==# '|& tee')
         \ && a:request.format !~# '%\\[er]'
   let session = get(g:, 'tmux_session', '')
   let script = dispatch#isolate(a:request, ['TMUX', 'TMUX_PANE'],


### PR DESCRIPTION
Hello,
When using dispatch with Fish shell set I get an empty output in all tmux windows while the command is running.

This fixes the output so the output shows while it is running.