### PR TITLE
Reduce install instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,9 +16,7 @@ mind.
 Install using your favorite package manager, or use Vim's built-in package
 support:
 
-    mkdir -p ~/.vim/pack/tpope/start
-    cd ~/.vim/pack/tpope/start
-    git clone https://tpope.io/vim/dispatch.git
+    git clone https://tpope.io/vim/dispatch.git ~/.vim/pack/tpope/start/dispatch
     vim -u NONE -c "helptags dispatch/doc" -c q
 
 


### PR DESCRIPTION
Fairly pointless change so feel free to close ;)

Edit: probably should mention that the `git clone` makes the intermediate directories so that’s why you do not need to use `mkdir`