### PR TITLE
Keep HOME env, or fish will raise warning

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -328,7 +328,7 @@ function! dispatch#set_title(request) abort
 endfunction
 
 function! dispatch#isolate(request, keep, ...) abort
-  let keep = ['SHELL'] + a:keep
+  let keep = ['SHELL', 'HOME'] + a:keep
   let command = ['cd ' . shellescape(getcwd())]
   for line in split(system('env'), "\n")
     let var = matchstr(line, '^\w\+\ze=')


### PR DESCRIPTION
```shell
> exec env -i SHELL="$SHELL" /usr/local/bin/fish
error: Your history will not be saved.
error: Unable to locate the data directory.
error: Please set the XDG_DATA_HOME or HOME environment variable before starting fish.

error: Your personal settings will not be saved.
error: Unable to locate the config directory.
error: Please set the XDG_CONFIG_HOME or HOME environment variable before starting fish.
```