### PR TITLE
Allow custom message handler

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -405,7 +405,13 @@ function! s:echo_truncated(left, right) abort
   if len(substitute(msg, '.', '.', 'g')) > max_len
     let msg = a:left . '<' . matchstr(a:right, '\v.{'.(max_len - len(substitute(a:left, '.', '.', 'g')) - 1).'}$')
   endif
-  echo msg
+
+  if exists('g:dispatch_message_handler')
+    call g:dispatch_message_handler(msg)
+  else
+    echo msg
+  endif
+
 endfunction
 
 function! s:dispatch(request) abort


### PR DESCRIPTION
This allows the user to do what they want with the echo message

(my usecase is sending it to neovim's vim.notify which will use https://gitlab.com/HiPhish/desktop-notify.nvim to send desktop notifications)