### PR TITLE
Check compiler_options.format instead of program

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -868,7 +868,7 @@ function! dispatch#compile_command(bang, args, count, mods, ...) abort
   if executable ==# '_' || executable ==# '--'
     if !empty(get(request, 'compiler', ''))
       let compiler_options = dispatch#compiler_options(request.compiler)
-      if !has_key(compiler_options, 'program')
+      if !has_key(compiler_options, 'format')
         return 'compiler ' . dispatch#fnameescape(request.compiler)
       endif
       call extend(request, compiler_options)
@@ -884,7 +884,7 @@ function! dispatch#compile_command(bang, args, count, mods, ...) abort
     let request.compiler = get(request, 'compiler', compiler)
     if !empty(request.compiler)
       let compiler_options = dispatch#compiler_options(request.compiler)
-      if !has_key(compiler_options, 'program')
+      if !has_key(compiler_options, 'format')
         return 'compiler ' . dispatch#fnameescape(request.compiler)
       endif
       call extend(request, compiler_options)

--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -878,7 +878,7 @@ function! dispatch#compile_command(bang, args, count, mods, ...) abort
       let request.format = &errorformat
     endif
     let request.args = s:default_args(args, exists('default_dispatch') && a:count < 0 ? 0 : a:count, request.format)
-    let request.command = s:build_make(request.program, request.args)
+    let request.command = s:build_make(get(request, 'program', get(request, 'compiler', '--')), request.args)
   else
     let [compiler, prefix, program, rest] = s:compiler_split(args)
     let request.compiler = get(request, 'compiler', compiler)


### PR DESCRIPTION
Some compilers (such as gcc) don't set makeprg and comipler_options.program will not be set, that breaks :Dispatch when use those comiplers.
Check compiler_options.format instead fix it and also give an error on :Dispatch -compiler=invalid.