### PR TITLE
Fix interpolated string of ruby

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -57,7 +57,7 @@ function! dispatch#shellescape(...) abort
   return join(args, ' ')
 endfunction
 
-let s:var = '\%(<\%(cword\|cWORD\|cexpr\|cfile\|sfile\|slnum\|afile\|abuf\|amatch' . (has('clientserver') ? '\|client' : '') . '\)>\|%\|#<\=\d\+\|##\=\)'
+let s:var = '\%(<\%(cword\|cWORD\|cexpr\|cfile\|sfile\|slnum\|afile\|abuf\|amatch' . (has('clientserver') ? '\|client' : '') . '\)>\|%\|#<\=\d\+\|\%(##\=\)\@!\%(#{\)\)'
 function! dispatch#escape(string) abort
   return substitute(a:string, s:var, '\\&', 'g')
 endfunction


### PR DESCRIPTION
Hi @tpope. I encountered an error when I run :Make with interpolated string in ruby. It will expand '#' to alternative file name.

You could reproduce this error by the following:

```console
vim test.rb

:e test2.rb
:Make -e 'a = 1; p "it's #{a}"'
```

Will output
<img width="660" alt="image" src="https://user-images.githubusercontent.com/41264693/178770999-4cc8a880-9be7-43e4-99b5-6fbb38f08af0.png">

And this PR will fix this,

Will output
<img width="591" alt="image" src="https://user-images.githubusercontent.com/41264693/178771317-dce3b47b-6844-4411-92d4-15a6a79106c3.png">



