### PR TITLE
Add usercmd to run after dispatch

### DIFF
--- a/autoload/dispatch.vim
+++ b/autoload/dispatch.vim
@@ -1253,6 +1253,7 @@ function! dispatch#complete(file, ...) abort
     if !a:0
       checktime
     endif
+    doautocmd User DispatchComplete
   endif
   return ''
 endfunction


### PR DESCRIPTION
This allows users to generically override dispatch with their custom behavior. Some kind of notification is required when the dispatch finishes.

For example, I wanted quickfix window to _always_ open. I have this in my vimrc:

```
	function KcDispatchComplete() abort
		Copen
	        " let the cursor stay where it is.
		normal G
		wincmd p
	endfunction
	autocmd User DispatchComplete call KcDispatchComplete()
```

Amazing plugin, thanks.